### PR TITLE
新增add命令功能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,187 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **ccs** (Claude配置切换工具) - a CLI tool for switching between different Claude API configurations. It's a Node.js command-line utility that helps users manage and switch between multiple Claude API endpoint configurations.
+
+## Architecture
+
+### Core Components
+
+- **Main executable**: `index.js` - Single-file Node.js CLI application using Commander.js for command parsing
+- **Configuration management**: Reads from `~/.claude/apiConfigs.json` and `~/.claude/settings.json`
+- **Interactive UI**: Uses inquirer.js for interactive menus and chalk for colored terminal output
+
+### Key Functionality
+
+1. **Configuration switching**: Reads API configs from `~/.claude/apiConfigs.json` and updates `~/.claude/settings.json`
+2. **Interactive selection**: Provides both arrow-key navigation and manual index input
+3. **Current config detection**: Shows which configuration is currently active
+4. **Confirmation prompts**: Uses inquirer.js for user confirmation before switching
+
+### File Structure
+
+- `index.js`: Main application logic with all CLI commands and configuration management
+- `notify.js`: WeChat Work notification module with hook script generation
+- `health.js`: Health check module for API endpoint availability testing
+- `package.json`: Dependencies (commander, chalk, inquirer)
+- `example/`: Contains sample configuration files
+- `README.md`: Comprehensive Chinese documentation
+
+## Development Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Install globally for testing
+npm install -g .
+
+# No specific test/lint/build commands defined - this is a simple CLI tool
+```
+
+## Configuration Format
+
+The tool expects configuration files in `~/.claude/`:
+
+1. **apiConfigs.json**: Array of complete configuration objects
+   ```json
+   [
+     {
+       "name": "config-name",
+       "config": {
+         "env": {
+           "ANTHROPIC_BASE_URL": "https://example.com/api",
+           "ANTHROPIC_AUTH_TOKEN": "sk-...",
+           "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+         },
+         "permissions": {
+           "allow": [],
+           "deny": []
+         },
+         "model": "opus"
+       }
+     }
+   ]
+   ```
+
+2. **settings.json**: Current active configuration with user customizations
+   ```json
+   {
+     "_configName": "config-name",
+     "env": {
+       "ANTHROPIC_BASE_URL": "https://...",
+       "ANTHROPIC_AUTH_TOKEN": "sk-...",
+       "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
+     },
+     "permissions": {
+       "allow": [],
+       "deny": []
+     },
+     "model": "opus",
+     "alwaysThinkingEnabled": true
+   }
+   ```
+
+3. **notify.json**: WeChat Work notification configuration (optional)
+   ```json
+   {
+     "wechatWork": {
+       "webhookUrl": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=...",
+       "enabled": true
+     },
+     "hooks": {
+       "enabled": true,
+       "events": {
+         "Notification": { "enabled": true, "message": "..." },
+         "Stop": { "enabled": true, "message": "..." }
+       }
+     }
+   }
+   ```
+
+**Important** (v1.8.0+ behavior):
+- When switching configurations, **only 3 fields are updated**:
+  - `_configName` (new in v1.8.0)
+  - `env.ANTHROPIC_AUTH_TOKEN`
+  - `env.ANTHROPIC_BASE_URL`
+- **All other fields are preserved**: permissions, model, alwaysThinkingEnabled, hooks, statusLine, mcpServers, etc.
+- This allows users to maintain custom settings while quickly switching between API providers
+
+## Key Functions
+
+### index.js
+- `saveSettingsPreservingHooks()`: Merges new config while preserving hooks and statusLine (index.js:115)
+- `deepEqual()`: Deep comparison utility for configuration objects (index.js:148)
+- `getCurrentConfig()`: Identifies currently active configuration using deep comparison (index.js:171)
+- `listAndSelectConfig()`: Main interactive configuration selection (index.js:196)
+- `processSelectedConfig()`: Handles configuration switching with confirmation (index.js:314)
+- `addConfig()`: Interactive wizard for adding new API configurations (index.js:535)
+- `removeConfig()`: Interactive configuration removal with safety checks (index.js:643)
+- `readApiConfigs()` / `saveSettings()`: Configuration file I/O (index.js:52, 89)
+
+### notify.js
+- `setupNotifyConfig()`: Interactive WeChat Work webhook configuration (notify.js:343)
+- `setupClaudeCodeHooks()`: Automatically configures Claude Code hooks for notifications (notify.js:269)
+- `createWeChatNotifyScript()`: Generates hook script at ~/.claude/scripts/wechat-notify.js (notify.js:127)
+- `sendWeChatWorkNotification()`: Sends messages via WeChat Work webhook (notify.js:76)
+
+### health.js
+- `checkConfigHealth()`: Intelligent endpoint probing with fallback strategies (health.js:106)
+- `probeEndpoint()`: Tests individual endpoint with timeout and latency measurement (health.js:45)
+- Supports multiple endpoint formats: /v1/models, /v1/chat/completions, /health, etc.
+
+## CLI Commands
+
+### Configuration Management
+- `ccs list` / `ccs ls`: Interactive configuration selection with both arrow-key and manual input
+- `ccs add`: Add new API configuration interactively
+- `ccs remove` / `ccs rm`: Remove API configuration with safety warnings
+- `ccs o api`: Open apiConfigs.json in default editor
+- `ccs o setting`: Open settings.json in default editor
+
+### Health Monitoring
+- `ccs health`: Check all API endpoints for availability and latency
+  - Automatically deduplicates URLs
+  - Tests multiple endpoint formats with intelligent fallback
+  - Displays real-time status with color-coded results
+
+### Notification Setup
+- `ccs notify setup` / `ccs ntf setup`: Configure WeChat Work webhook
+- `ccs notify status`: View current notification configuration
+- `ccs notify test`: Send test notification
+
+### General
+- `ccs --version` / `ccs -v`: Show version info
+
+## Important Notes
+
+### User Experience
+- All user interactions are in Chinese
+- Configuration files are automatically created in `~/.claude/` directory
+- Uses inquirer.js with default confirmation (Enter = Yes)
+- Supports both interactive menu navigation and manual index input
+- After switching config, optionally launches `claude` CLI in current directory (index.js:343-372)
+
+### Configuration Behavior (v1.8.0+)
+- **Selective update strategy**: Only updates API credentials when switching configurations
+  - Updates: `_configName`, `env.ANTHROPIC_AUTH_TOKEN`, `env.ANTHROPIC_BASE_URL`
+  - Preserves: All other fields (permissions, model, alwaysThinkingEnabled, hooks, statusLine, mcpServers, etc.)
+- **Config name tracking**: `_configName` field automatically added to settings.json (index.js:140)
+- **Smart matching**: Priority matching by `_configName`, fallback to URL/Token comparison (index.js:193-209)
+- **Backward compatible**: Works with settings.json files from older versions
+- Configuration names must be unique when adding new configs (index.js:547)
+
+### Notification System
+- Notification setup automatically generates hook script at `~/.claude/scripts/wechat-notify.js`
+- Hook script listens for `Notification` and `Stop` events from Claude Code
+- Notification hooks are preserved during config switches
+- Token display is masked (first 7 chars + ****) for security (health.js:181)
+
+### Health Check
+- Deduplicates URLs to avoid redundant checks (health.js:214)
+- Tests multiple endpoints in sequence until 2xx response found
+- Treats 2xx and 4xx as "reachable", 5xx and network errors as "unhealthy"
+- 30-second timeout per endpoint probe (health.js:66)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,156 @@
+# Claude Config Switch (CCS) 快速使用指南
+
+## 🚀 v1.8.0 重要更新
+
+**现在切换配置时只会更新 API 凭证，保留所有其他自定义设置！**
+
+## 📦 安装/更新
+
+```bash
+# 本地安装
+cd claude-code-switch
+npm install -g .
+
+# 或从 npm 安装
+npm i -g claude-config-switch
+```
+
+## 🎯 核心功能
+
+### 1. 切换 API 配置（保留自定义设置）
+
+```bash
+# 交互式切换
+ccs list
+# 或
+ccs ls
+
+# 直接切换到第2个配置
+ccs use 2
+```
+
+**新行为（v1.8.0+）**：
+- ✅ 只更新：API Token、Base URL、配置名称
+- ✅ 保留：permissions、model、alwaysThinkingEnabled、hooks、MCP 等所有自定义配置
+
+### 2. 验证当前配置
+
+```bash
+# 查看当前配置状态
+node verify-config.js
+```
+
+### 3. 添加/删除配置
+
+```bash
+# 添加新配置
+ccs add
+
+# 删除配置
+ccs remove
+# 或
+ccs rm
+```
+
+### 4. 健康检查
+
+```bash
+# 检查所有 API 端点的可用性
+ccs health
+```
+
+### 5. 企微通知
+
+```bash
+# 设置企微通知
+ccs notify setup
+
+# 查看通知状态
+ccs notify status
+
+# 测试通知
+ccs notify test
+```
+
+## 📝 配置文件
+
+### `~/.claude/apiConfigs.json`
+存储所有可用的 API 配置：
+```json
+[
+  {
+    "name": "config-1",
+    "config": {
+      "env": {
+        "ANTHROPIC_AUTH_TOKEN": "sk-...",
+        "ANTHROPIC_BASE_URL": "https://..."
+      }
+    }
+  }
+]
+```
+
+### `~/.claude/settings.json`
+当前激活的配置 + 你的自定义设置：
+```json
+{
+  "_configName": "config-1",
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-...",
+    "ANTHROPIC_BASE_URL": "https://..."
+  },
+  "alwaysThinkingEnabled": true,
+  "mcpServers": { ... },
+  // 你的其他自定义配置
+}
+```
+
+## 💡 典型使用场景
+
+### 场景 1：保留自定义配置，只换 API
+
+```bash
+# 你的 settings.json 中配置了很多东西
+# - alwaysThinkingEnabled: true
+# - 自定义 MCP 服务器
+# - 自定义权限等
+
+# 现在想换个 API 提供商
+ccs list
+# 选择新的配置
+
+# ✅ 只有 API 变了，其他配置都保留！
+```
+
+### 场景 2：快速测试不同 API
+
+```bash
+# API 1 不行了，快速切换
+ccs list  # 选择 API 2
+
+# API 2 也不行，继续切换
+ccs list  # 选择 API 3
+
+# 无需担心配置丢失！
+```
+
+## ⚠️ 重要提示
+
+1. **从旧版本升级**：首次切换配置会自动添加 `_configName` 字段，无需手动操作
+2. **自定义配置**：所有在 settings.json 中的自定义字段都会被保留
+3. **配置文件**：apiConfigs.json 只需存储不同的 API 凭证，其他配置在 settings.json 中维护
+
+## 🔧 常用命令速查
+
+```bash
+ccs list          # 切换配置
+ccs add           # 添加配置
+ccs rm            # 删除配置
+ccs health        # 健康检查
+ccs --version     # 查看版本
+ccs --help        # 查看帮助
+```
+
+## 📚 完整文档
+
+详见 [README.md](README.md)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ npm install -g .
 
 ```json
 {
+  "_configName": "zone",
   "env": {
     "ANTHROPIC_BASE_URL": "https://zone.veloera.org/pg",
     "ANTHROPIC_AUTH_TOKEN": "sk-XXXXXXX",
@@ -99,11 +100,60 @@ npm install -g .
     "allow": [],
     "deny": []
   },
-  "model": "claude-sonnet-4-20250514"
+  "model": "claude-sonnet-4-20250514",
+  "alwaysThinkingEnabled": true
 }
 ```
 
-**注意**：切换配置时，整个 `settings.json` 文件会被选中配置的 `config` 对象完全替换。
+**重要说明**：
+
+⚡ **配置切换行为（v1.8.0+ 重要更新）**
+
+从 v1.8.0 开始，切换配置时的行为已优化：
+
+- ✅ **只更新 API 凭证**：切换时仅更新以下 3 个字段
+  - `_configName` - 当前配置名称（新增）
+  - `env.ANTHROPIC_AUTH_TOKEN` - API 密钥
+  - `env.ANTHROPIC_BASE_URL` - API 端点
+
+- ✅ **保留所有其他设置**：以下配置完全保留
+  - `permissions` - 权限设置
+  - `model` - 模型配置
+  - `alwaysThinkingEnabled` - 思考模式
+  - `hooks` - 钩子配置
+  - `statusLine` - 状态栏配置
+  - `mcpServers` - MCP 服务器配置
+  - 任何其他自定义字段
+
+**使用场景**：
+```bash
+# 场景：你的 settings.json 中有很多自定义配置
+{
+  "env": { "ANTHROPIC_AUTH_TOKEN": "sk-old...", "ANTHROPIC_BASE_URL": "..." },
+  "alwaysThinkingEnabled": true,
+  "mcpServers": { "custom-server": {...} },
+  "permissions": { "allow": ["somePermission"] },
+  "customFeature": true
+}
+
+# 执行 ccs list 切换到新配置后
+{
+  "_configName": "new-config",  // ⚡ 已更新
+  "env": {
+    "ANTHROPIC_AUTH_TOKEN": "sk-new...",  // ⚡ 已更新
+    "ANTHROPIC_BASE_URL": "https://new-url.com"  // ⚡ 已更新
+  },
+  "alwaysThinkingEnabled": true,  // ✅ 保留
+  "mcpServers": { "custom-server": {...} },  // ✅ 保留
+  "permissions": { "allow": ["somePermission"] },  // ✅ 保留
+  "customFeature": true  // ✅ 保留
+}
+```
+
+💡 **建议**：
+- `apiConfigs.json` 只需存储不同的 API 凭证信息
+- 在 `settings.json` 中配置你的个性化设置（permissions、model、MCP 等）
+- 切换 API 时无需担心丢失自定义配置
 
 ### 命令
 
@@ -431,11 +481,34 @@ ccs unknown
 - 确保 `~/.claude/apiConfigs.json` 和 `~/.claude/settings.json` 文件存在并包含有效的配置信息
 - 工具会自动创建 `~/.claude` 目录（如果不存在）
 - 确认操作时默认为"是"，直接按Enter键即可确认
-- 切换配置时会完全替换 `settings.json` 文件内容
+- **v1.8.0+**: 切换配置时只更新 API 凭证，保留所有其他自定义设置（详见上方"配置切换行为"说明）
 - 使用 `ntf` 命令需要先在企微群中添加机器人并获取Webhook地址
 - `notify.json` 文件首次使用时会自动创建
 
 ## 更新日志
+
+### 1.8.0 配置切换优化（重要更新）⚡
+
+**重大改进：智能配置保留机制**
+
++ **配置切换优化**: 切换配置时只更新 API 凭证，保留所有其他设置
+  - 只更新：`_configName`、`ANTHROPIC_AUTH_TOKEN`、`ANTHROPIC_BASE_URL`
+  - 保留：`permissions`、`model`、`alwaysThinkingEnabled`、`hooks`、`statusLine`、`mcpServers` 等所有自定义字段
++ **新增配置名称标记**: settings.json 中新增 `_configName` 字段，记录当前使用的配置
++ **改进配置匹配**: 优先使用配置名称匹配，提升匹配速度和准确性
++ **向后兼容**: 完全兼容旧版本的配置文件格式
+
+**升级说明**：
+- 从旧版本升级后，首次切换配置会自动添加 `_configName` 字段
+- 现有的自定义配置（如 `alwaysThinkingEnabled`）不会丢失
+- 无需手动迁移配置文件
+
+**典型使用场景**：
+```bash
+# 你可以在 settings.json 中配置 MCP、自定义权限等
+# 然后通过 ccs list 快速切换不同的 API 提供商
+# 无需担心自定义配置被覆盖
+```
 
 ### 1.7.0 健康检查
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-config-switch",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Claude配置切换工具及其他工具",
   "main": "index.js",
   "bin": {

--- a/verify-config.js
+++ b/verify-config.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+/**
+ * 验证配置切换前后的字段保留情况
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SETTINGS_FILE = path.join(os.homedir(), '.claude', 'settings.json');
+
+console.log('📋 当前 settings.json 配置:\n');
+
+const settings = JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8'));
+
+console.log('🔑 API 配置:');
+console.log(`  配置名称: ${settings._configName || '(未设置)'}`);
+console.log(`  Base URL: ${settings.env?.ANTHROPIC_BASE_URL || '(未设置)'}`);
+console.log(`  API Token: ${settings.env?.ANTHROPIC_AUTH_TOKEN?.substring(0, 15)}...` || '(未设置)');
+
+console.log('\n🛠️  其他保留的配置:');
+console.log(`  alwaysThinkingEnabled: ${settings.alwaysThinkingEnabled !== undefined ? settings.alwaysThinkingEnabled : '(未设置)'}`);
+console.log(`  model: ${settings.model || '(未设置)'}`);
+console.log(`  permissions: ${JSON.stringify(settings.permissions || {})}`);
+console.log(`  hooks: ${settings.hooks ? '已配置' : '(未配置)'}`);
+console.log(`  statusLine: ${settings.statusLine ? '已配置' : '(未配置)'}`);
+
+console.log('\n💡 提示:');
+console.log('  切换配置后，只有 _configName、ANTHROPIC_AUTH_TOKEN 和 ANTHROPIC_BASE_URL 会变化');
+console.log('  其他所有字段（alwaysThinkingEnabled、permissions、hooks 等）都会保留');


### PR DESCRIPTION
主要改进：
1. 新增saveApiConfigs()函数用于保存API配置文件
2. 新增addConfig()函数，支持交互式添加新配置
3. 新增ccs add命令，可添加新的Claude API配置
4. model字段可选，不填则不保存该字段
5. 添加配置名称重复检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)